### PR TITLE
Convert to plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["./index.js"],
+  extends: ["plugin:@foxglove/base"],
   env: { node: true },
   parserOptions: {
     project: "tsconfig.json",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,4 @@ jobs:
         with:
           node-version: 16.x
       - run: npm install
-      - run: npm run lint
-      - run: npm run lint:react
-      - run: npm run lint:typescript
+      - run: npm run lint:all

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# @foxglove/eslint-config
+# @foxglove/eslint-plugin
 
-[![npm package](https://img.shields.io/npm/v/@foxglove/eslint-config)](https://www.npmjs.com/package/@foxglove/eslint-config)
+[![npm package](https://img.shields.io/npm/v/@foxglove/eslint-plugin)](https://www.npmjs.com/package/@foxglove/eslint-plugin)
 
-Foxglove default eslint configuration.
+Foxglove default eslint configuration & rules.
 
-Err on the side of conservative changes to this repo - multiple Foxglove projects should successfully adopt a change before making it a default.
+Please err on the side of conservative changes to this repo - multiple Foxglove projects should adopt a change before making it a default.
 
 ## Installation
 
 The following configurations are available:
 
-- `@foxglove/eslint-config` (automatically imported by other configs)
-- `@foxglove/eslint-config/react`
-- `@foxglove/eslint-config/typescript`
+- `plugin:@foxglove/base` (automatically imported by other configurations)
+- `plugin:@foxglove/react`
+- `plugin:@foxglove/typescript`
 
 **Typescript + React Example**
 
 ```sh
 yarn add -D \
     eslint \
-    @foxglove/eslint-config \
+    @foxglove/eslint-plugin \
     @typescript-eslint/eslint-plugin \
     @typescript-eslint/parser \
     eslint-config-prettier \
@@ -34,10 +34,7 @@ In your `.eslintrc.js`:
 
 ```js
 module.exports = {
-  extends: [
-    "@foxglove/eslint-config/react",
-    "@foxglove/eslint-config/typescript",
-  ],
+  extends: ["plugin:@foxglove/react", "plugin:@foxglove/typescript"],
   parserOptions: {
     project: "tsconfig.json",
   },
@@ -45,6 +42,8 @@ module.exports = {
 ```
 
 ## Releasing
+
+You must use npm 7+ (not yarn) to test this repo locally, due to the self link in `package.json`.
 
 ```sh
 npm version [major|minor|patch]

--- a/configs/base.js
+++ b/configs/base.js
@@ -1,0 +1,72 @@
+module.exports = {
+  extends: ["eslint:recommended", "plugin:prettier/recommended"],
+  plugins: ["@foxglove", "file-progress", "import"],
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: "module",
+  },
+  rules: {
+    // show progress while linting
+    "file-progress/activate": 1,
+
+    // import plugin is slow, only enable the critical stuff
+    "import/export": "error",
+    "import/first": "error",
+    "import/named": "error",
+    "import/newline-after-import": "error",
+    "import/no-duplicates": "error",
+    "import/no-mutable-exports": "error",
+    "import/no-useless-path-segments": "error",
+    "import/order": [
+      "error",
+      {
+        alphabetize: {
+          order: "asc",
+        },
+        "newlines-between": "always",
+        groups: [
+          ["builtin", "external"],
+          ["internal"],
+          ["parent", "sibling", "index"],
+        ],
+      },
+    ],
+
+    // require double equal for undefined, triple equal everywhere else
+    "@foxglove/strict-equality": "error",
+
+    // require curly braces everywhere
+    curly: "error",
+
+    // avoid eval
+    "no-eval": "error",
+    "no-implied-eval": "error",
+    "no-new-func": "error",
+
+    // unused vars must have `_` prefix
+    "no-unused-vars": [
+      "error",
+      {
+        vars: "all",
+        args: "after-used",
+        varsIgnorePattern: "^_",
+        argsIgnorePattern: "^_",
+      },
+    ],
+
+    "no-underscore-dangle": [
+      "error",
+      {
+        allowAfterThis: true,
+      },
+    ],
+
+    // avoid TO.DO and FIX.ME comments, create a ticket to track future work
+    "no-warning-comments": [
+      "error",
+      {
+        location: "anywhere",
+      },
+    ],
+  },
+};

--- a/configs/react.js
+++ b/configs/react.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: [
-    "./index.js",
+    "plugin:@foxglove/base",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
   ],

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["./index.js"],
+  extends: ["plugin:@foxglove/base"],
   overrides: [
     {
       files: ["*.ts", "*.tsx"],
@@ -10,6 +10,9 @@ module.exports = {
       ],
       parser: "@typescript-eslint/parser",
       rules: {
+        // Avoid #member syntax for performance
+        "@foxglove/no-private-identifier": "error",
+
         // `<T>x` style assertions are not compatible with JSX code,
         // so for consistency we prefer `x as T` everywhere.
         "@typescript-eslint/consistent-type-assertions": [
@@ -60,16 +63,6 @@ module.exports = {
 
         // require all cases to be checked in switch statements
         "@typescript-eslint/switch-exhaustiveness-check": "error",
-
-        "no-restricted-syntax": [
-          "error",
-          // #member is slow, see https://github.com/foxglove/studio/pull/430
-          {
-            selector: "TSPrivateIdentifier",
-            message:
-              "Unexpected #member syntax, prefer private keyword for performance",
-          },
-        ],
       },
     },
   ],

--- a/index.js
+++ b/index.js
@@ -1,92 +1,11 @@
 module.exports = {
-  extends: ["eslint:recommended", "plugin:prettier/recommended"],
-  plugins: ["file-progress", "import"],
-  parserOptions: {
-    ecmaVersion: 2020,
-    sourceType: "module",
-  },
   rules: {
-    // show progress while linting
-    "file-progress/activate": 1,
-
-    // import plugin is slow, only enable the critical stuff
-    "import/export": "error",
-    "import/first": "error",
-    "import/named": "error",
-    "import/newline-after-import": "error",
-    "import/no-duplicates": "error",
-    "import/no-mutable-exports": "error",
-    "import/no-useless-path-segments": "error",
-    "import/order": [
-      "error",
-      {
-        alphabetize: {
-          order: "asc",
-        },
-        "newlines-between": "always",
-        groups: [
-          ["builtin", "external"],
-          ["internal"],
-          ["parent", "sibling", "index"],
-        ],
-      },
-    ],
-
-    // require curly braces everywhere
-    curly: "error",
-
-    // avoid eval
-    "no-eval": "error",
-    "no-implied-eval": "error",
-    "no-new-func": "error",
-
-    // unused vars must have `_` prefix
-    "no-unused-vars": [
-      "error",
-      {
-        vars: "all",
-        args: "after-used",
-        varsIgnorePattern: "^_",
-        argsIgnorePattern: "^_",
-      },
-    ],
-
-    "no-restricted-syntax": [
-      "error",
-      // prefer triple equals (eqeqeq), except prefer double equals for null and undefined
-      {
-        selector:
-          "BinaryExpression:matches([operator='=='], [operator='!=']):matches([left.type=Literal][left.raw=null], [right.type=Literal][right.raw=null])",
-        message:
-          'Prefer "x == undefined" or "x != undefined" to check for both null and undefined.',
-      },
-      {
-        selector:
-          "BinaryExpression:matches([operator='=='], [operator='!='])[left.type=Identifier][left.name=undefined]",
-        message:
-          'Prefer "x == undefined" or "x != undefined" to check for both null and undefined.',
-      },
-      {
-        selector:
-          "BinaryExpression:matches([operator='=='], [operator='!=']):not([right.type=Identifier][right.name=undefined]):not([right.type=Literal][right.raw=null])",
-        message:
-          'Use strict equality operators "===" and "!==", except when checking for null or undefined.',
-      },
-    ],
-
-    "no-underscore-dangle": [
-      "error",
-      {
-        allowAfterThis: true,
-      },
-    ],
-
-    // avoid TO.DO and FIX.ME comments, create a ticket to track future work
-    "no-warning-comments": [
-      "error",
-      {
-        location: "anywhere",
-      },
-    ],
+    "strict-equality": require("./rules/strict-equality"),
+    "no-private-identifier": require("./rules/no-private-identifier"),
+  },
+  configs: {
+    base: require("./configs/base"),
+    react: require("./configs/react"),
+    typescript: require("./configs/typescript"),
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,26 +1,29 @@
 {
-  "name": "@foxglove/eslint-config",
+  "name": "@foxglove/eslint-plugin",
   "version": "0.3.0",
-  "description": "Foxglove default eslint configuration",
+  "description": "Foxglove eslint configuration",
   "license": "MIT",
   "main": "index.js",
   "files": [
-    "*.js"
+    "**/*.js"
   ],
   "scripts": {
     "lint": "eslint .",
-    "lint:react": "eslint -c react.js .",
-    "lint:typescript": "eslint -c typescript.js .",
-    "lint:all": "eslint -c react.js -c typescript.js ."
+    "lint:base": "eslint --no-eslintrc --config ./configs/base.js --env node .",
+    "lint:react": "eslint --no-eslintrc --config ./configs/react.js --env node .",
+    "lint:typescript": "eslint --no-eslintrc --config ./configs/typescript.js --env node .",
+    "lint:all": "npm run lint && npm run lint:base && npm run lint:react && npm run lint:typescript"
   },
   "peerDependencies": {
     "eslint": "^7",
     "eslint-config-prettier": "^8",
     "eslint-plugin-file-progress": "^1",
     "eslint-plugin-import": "^2",
-    "eslint-plugin-prettier": "^3"
+    "eslint-plugin-prettier": "^3",
+    "prettier": "^2"
   },
   "devDependencies": {
+    "@foxglove/eslint-plugin": "file:.",
     "@typescript-eslint/eslint-plugin": "^4",
     "@typescript-eslint/parser": "^4",
     "eslint-plugin-react": "^7",

--- a/rules/no-private-identifier.js
+++ b/rules/no-private-identifier.js
@@ -1,0 +1,19 @@
+// #member is slow, see https://github.com/foxglove/studio/pull/430
+module.exports = {
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    schema: [],
+  },
+
+  create: function (context) {
+    return {
+      TSPrivateIdentifier: function (node) {
+        context.report({
+          node,
+          message: `Unexpected '${node.escapedText}', prefer private keyword for performance`,
+        });
+      },
+    };
+  },
+};

--- a/rules/strict-equality.js
+++ b/rules/strict-equality.js
@@ -1,9 +1,9 @@
 const eqeqeq = require("eslint/lib/rules/eqeqeq");
 const astUtils = require("eslint/lib/rules/utils/ast-utils");
 
-// - Prefer double equals when comparing with undefined.
-// - Prefer undefined over null.
-// - Prefer triple equals everywhere else.
+// - Prefer double equals when comparing with undefined
+// - Prefer undefined over null
+// - Prefer triple equals everywhere else
 module.exports = {
   meta: {
     type: "suggestion",
@@ -24,22 +24,26 @@ module.exports = {
 
     return {
       BinaryExpression: function (node) {
+        function report(node, loc) {
+          let expectedOp = node.operator.substring(0, 2);
+
+          context.report({
+            node,
+            loc,
+            message: `Prefer 'x ${expectedOp} undefined' to catch both null and undefined`,
+          });
+        }
+
         // If either side is undefined, prefer double equals
         if (isUndefinedLiteral(node.left) || isUndefinedLiteral(node.right)) {
           if (node.operator === "===" || node.operator === "!==") {
-            let expectedOp = node.operator.substring(0, 2);
-
             const operatorToken = sourceCode.getFirstTokenBetween(
               node.left,
               node.right,
               (token) => token.value === node.operator
             );
 
-            context.report({
-              node,
-              loc: operatorToken.loc,
-              message: `Prefer 'x ${expectedOp} undefined' to check both null and undefined`,
-            });
+            report(node, operatorToken.loc);
           }
         }
 
@@ -48,11 +52,7 @@ module.exports = {
           astUtils.isNullLiteral(node.left) ||
           astUtils.isNullLiteral(node.right)
         ) {
-          let expectedOp = node.operator.substring(0, 2);
-          context.report({
-            node,
-            message: `Prefer 'x ${expectedOp} undefined' to check both null and undefined`,
-          });
+          report(node, node.loc);
         }
 
         // Otherwise, fall through to eqeqeq rule

--- a/rules/strict-equality.js
+++ b/rules/strict-equality.js
@@ -1,0 +1,66 @@
+const eqeqeq = require("eslint/lib/rules/eqeqeq");
+const astUtils = require("eslint/lib/rules/utils/ast-utils");
+
+// - Prefer double equals when comparing with undefined.
+// - Prefer undefined over null.
+// - Prefer triple equals everywhere else.
+module.exports = {
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    schema: [],
+    messages: {
+      unexpected: "Prefer '{{expectedOperator}}' over '{{actualOperator}}'.",
+    },
+  },
+
+  create: function (context) {
+    const tripleEq = eqeqeq.create(context);
+    const sourceCode = context.getSourceCode();
+
+    function isUndefinedLiteral(node) {
+      return node.type === "Identifier" && node.name === "undefined";
+    }
+
+    return {
+      BinaryExpression: function (node) {
+        // If either side is undefined, prefer double equals
+        if (isUndefinedLiteral(node.left) || isUndefinedLiteral(node.right)) {
+          if (node.operator === "===" || node.operator === "!==") {
+            let expectedOp = node.operator.substring(0, 2);
+
+            const operatorToken = sourceCode.getFirstTokenBetween(
+              node.left,
+              node.right,
+              (token) => token.value === node.operator
+            );
+
+            context.report({
+              node,
+              loc: operatorToken.loc,
+              message: `Prefer 'x ${expectedOp} undefined' to check both null and undefined`,
+            });
+          }
+        }
+
+        // If either side is null, prefer undefined
+        else if (
+          astUtils.isNullLiteral(node.left) ||
+          astUtils.isNullLiteral(node.right)
+        ) {
+          let expectedOp = node.operator.substring(0, 2);
+          context.report({
+            node,
+            message: `Prefer 'x ${expectedOp} undefined' to check both null and undefined`,
+          });
+        }
+
+        // Otherwise, fall through to eqeqeq rule
+        // We don't need to configure it since null and undefined were already checked
+        else {
+          tripleEq.BinaryExpression(node);
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
- Convert from eslint config to eslint plugin (import syntax is slightly different)
- Convert use of `no-restricted-syntax` to custom rules, to avoid problems with overriding (if overrides add `no-restricted-syntax` it replaces rather than adds rules, which is almost certainly unexpected)
- Add self reference in `package.json` so that `react` and `typescript` configs can import `base`. 