### PR TITLE
Require manual import of base config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please err on the side of conservative changes to this repo - multiple Foxglove 
 
 The following configurations are available:
 
-- `plugin:@foxglove/base` (automatically imported by other configurations)
+- `plugin:@foxglove/base`
 - `plugin:@foxglove/react`
 - `plugin:@foxglove/typescript`
 
@@ -35,7 +35,7 @@ In your `.eslintrc.js`:
 
 ```js
 module.exports = {
-  extends: ["plugin:@foxglove/react"],
+  extends: ["plugin:@foxglove/base", "plugin:@foxglove/react"],
   overrides: [
     {
       files: ["*.ts", "*.tsx"],

--- a/configs/react.js
+++ b/configs/react.js
@@ -1,9 +1,5 @@
 module.exports = {
-  extends: [
-    "plugin:@foxglove/base",
-    "plugin:react/recommended",
-    "plugin:react-hooks/recommended",
-  ],
+  extends: ["plugin:react/recommended", "plugin:react-hooks/recommended"],
   settings: {
     react: {
       version: "detect",

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -1,6 +1,5 @@
 module.exports = {
   extends: [
-    "plugin:@foxglove/base",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "plugin:import/typescript",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,9 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "lint:base": "eslint --no-eslintrc --config ./configs/base.js --env node .",
-    "lint:react": "eslint --no-eslintrc --config ./configs/react.js --env node .",
-    "lint:typescript": "eslint --no-eslintrc --config ./configs/typescript.js --parser-options '{project:\"tsconfig.json\"}' --env node *.ts",
-    "lint:all": "npm run lint && npm run lint:base && npm run lint:react && npm run lint:typescript"
+    "lint:react": "eslint --config ./configs/react.js",
+    "lint:typescript": "eslint --config ./configs/typescript.js *.ts",
+    "lint:all": "npm run lint && npm run lint:react && npm run lint:typescript"
   },
   "peerDependencies": {
     "eslint": "^7",


### PR DESCRIPTION
Automatically depending on base caused issues, because if `@foxglove/typescript` was imported in an override, that would re-import our base config, which would then override any base customization that the consumer did at the global scope.

It's therefore easier to just let people manually import base.