### PR TITLE
Remove eslint-plugin-file-progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ yarn add -D \
     @typescript-eslint/parser \
     eslint \
     eslint-config-prettier \
-    eslint-plugin-file-progress \
     eslint-plugin-import \
     eslint-plugin-prettier \
     eslint-plugin-react \

--- a/configs/base.js
+++ b/configs/base.js
@@ -1,14 +1,11 @@
 module.exports = {
   extends: ["eslint:recommended", "plugin:prettier/recommended"],
-  plugins: ["@foxglove", "file-progress", "import"],
+  plugins: ["@foxglove", "import"],
   parserOptions: {
     ecmaVersion: 2020,
     sourceType: "module",
   },
   rules: {
-    // show progress while linting
-    "file-progress/activate": 1,
-
     // import plugin is slow, only enable the critical stuff
     "import/export": "error",
     "import/first": "error",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "peerDependencies": {
     "eslint": "^7",
     "eslint-config-prettier": "^8",
-    "eslint-plugin-file-progress": "^1",
     "eslint-plugin-import": "^2",
     "eslint-plugin-prettier": "^3",
     "prettier": "^2"


### PR DESCRIPTION
Per https://github.com/foxglove/eslint-plugin/pull/4#discussion_r642585921 - this is unnecessary for small projects, so better if we leave it out of shared config.