### PR TITLE
Remove @typescript-eslint/strict-boolean-expressions

### DIFF
--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -51,15 +51,6 @@ module.exports = {
       },
     ],
 
-    // require explicit boolean checks in conditionals
-    "@typescript-eslint/strict-boolean-expressions": [
-      "error",
-      {
-        allowString: false,
-        allowNumber: false,
-      },
-    ],
-
     // require all cases to be checked in switch statements
     "@typescript-eslint/switch-exhaustiveness-check": "error",
   },


### PR DESCRIPTION
This setting is rather aggressive, preventing simple checks such as `if (!process.env.FOO_VARIABLE)`. It is not included in `@typescript-eslint/recommended`.

In the studio repo, we have [helpers](https://github.com/foxglove/studio/blob/main/packages/studio-base/src/util/emptyOrUndefined.ts) to make checking for empty or undefined values easier. However, other repos don't have these available.

I therefore propose we remove it from our default shared config, and enable it on the studio repo only.