### PR TITLE
Reconfigure @typescript-eslint/strict-boolean-expressions

### DIFF
--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -53,5 +53,20 @@ module.exports = {
 
     // require all cases to be checked in switch statements
     "@typescript-eslint/switch-exhaustiveness-check": "error",
+
+    // require strict boolean comparisons for all types, except allow
+    // nullable string conditionals to avoid verbose "empty or undefined" checks
+    "@typescript-eslint/strict-boolean-expressions": [
+      "error",
+      {
+        allowString: true,
+        allowNullableString: true,
+        allowNumber: false,
+        allowNullableNumber: false,
+        allowNullableBoolean: false,
+        allowNullableObject: false,
+        allowAny: false,
+      },
+    ],
   },
 };


### PR DESCRIPTION
Follow up from discussion in https://github.com/foxglove/eslint-plugin/pull/13 (note that studio repo overrides this default so it does not apply at all, although we could separately standardize that if we want).

New proposed defaults:

```
let x: string;
if (x) {...} // allowed

let x: string | undefined;
if (x) {...} // allowed


let x: boolean;
if (x) {...} // allowed, obviously

let x: boolean | undefined;
if (x) {...} // allowed


let x: number;
if (x) {...} // not allowed

let x: number | undefined;
if (x) {...} // not allowed


let x: { foo: unknown };
if (x) {...} // not allowed

let x: { foo: unknown } | undefined;
if (x) {...} // not allowed
```