### PR TITLE
Allow double equal null checks

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -29,7 +29,7 @@ module.exports = {
       },
     ],
 
-    // require double equal for undefined, triple equal everywhere else
+    // require double equal for null and undefined, triple equal everywhere else
     "@foxglove/strict-equality": "error",
 
     // require curly braces everywhere


### PR DESCRIPTION
Previously, we required double equals for undefined checks, and required converting all `null` equality checks to `undefined`.

Since `null` isn't banned in other repos, relax this rule to allow double equals null. However, we still do not allow triple equals null or triple equals undefined.

In case you're wondering, in JS null and undefined double equal each other, but only triple equal themselves. They do not otherwise double equal false. Therefore, it is safe to use double equals for checking null and undefined, unless you specifically wanted to differentiate between them (if that is needed you should disable this rule on a per-line basis - I've never seen it needed).

```js
> null == undefined
true
> null === undefined
false
> null == false
false
> undefined == false
false
```