### PR TITLE
Add `no-meaningless-void-operator` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ module.exports = {
 
 You can add `"plugin:@foxglove/typescript"` to the top level `extends` instead of using `overrides` if your project contains no `.js` files.
 
+## Rules
+
+See [rules/README.md](rules/README.md) for details on each rule.
+
 ## License
 
 @foxglove/eslint-plugin is released under the [MIT License](/LICENSE.md).

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -8,6 +8,7 @@ module.exports = {
   rules: {
     // Avoid #member syntax for performance
     "@foxglove/no-private-identifier": "error",
+    "@foxglove/no-meaningless-void-operator": "error",
 
     // `<T>x` style assertions are not compatible with JSX code,
     // so for consistency we prefer `x as T` everywhere.

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = {
     "license-header": require("./rules/license-header"),
     "no-private-identifier": require("./rules/no-private-identifier"),
     "strict-equality": require("./rules/strict-equality"),
+    "no-meaningless-void-operator": require("./rules/no-meaningless-void-operator"),
   },
   configs: {
     base: require("./configs/base"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,8 +168,8 @@
       }
     },
     "node_modules/@foxglove/eslint-plugin": {
-      "resolved": "",
-      "link": true
+      "link": true,
+      "resolved": ""
     },
     "node_modules/@foxglove/tsconfig": {
       "version": "1.0.0",
@@ -2940,7 +2940,7 @@
       "version": "file:",
       "requires": {
         "@foxglove/eslint-plugin": "file:",
-        "@foxglove/tsconfig": "*",
+        "@foxglove/tsconfig": "1.0.0",
         "@typescript-eslint/eslint-plugin": "^4",
         "@typescript-eslint/parser": "^4",
         "eslint-plugin-jest": "^24",

--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,36 @@
+## Rules
+
+The following rules are provided by `@foxglove/eslint-plugin`.
+
+**Key:** 🔧 = fixable, 💭 = requires type information (TypeScript only)
+
+### [`@foxglove/no-meaningless-void-operator`](./no-meaningless-void-operator.js) 💭 🔧
+
+Disallow the `void` operator when its argument is already of type `void` or `undefined`.
+
+The `void` operator is a useful tool to convey the programmer's intent to discard a value. For example, it is recommended as one way of suppressing [`@typescript-eslint/no-floating-promises`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-floating-promises.md) instead of adding `.catch()` to a promise.
+
+This rule helps an author catch API changes where previously a value was being discarded at a call site, but the callee changed so it no longer returns a value. When combined with [no-unused-expressions](https://eslint.org/docs/rules/no-unused-expressions), it also helps _readers_ of the code by ensuring consistency: a statement that looks like `void foo();` is **always** discarding a return value, and a statement that looks like `foo();` is **never** discarding a return value.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+void (() => {})();
+
+function foo() {}
+void foo();
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+(() => {})();
+
+function foo() {}
+foo(); // nothing to discard
+
+function bar() {
+  return 2;
+}
+void bar(); // discarding a number
+```

--- a/rules/README.md
+++ b/rules/README.md
@@ -6,7 +6,7 @@ The following rules are provided by `@foxglove/eslint-plugin`.
 
 ### [`@foxglove/no-meaningless-void-operator`](./no-meaningless-void-operator.js) 💭 🔧
 
-Disallow the `void` operator when its argument is already of type `void` or `undefined`.
+Disallow the `void` operator when its argument is already of type `void`, `undefined`, or `never`.
 
 The `void` operator is a useful tool to convey the programmer's intent to discard a value. For example, it is recommended as one way of suppressing [`@typescript-eslint/no-floating-promises`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-floating-promises.md) instead of adding `.catch()` to a promise.
 

--- a/rules/no-meaningless-void-operator.js
+++ b/rules/no-meaningless-void-operator.js
@@ -26,7 +26,8 @@ module.exports = {
           unionTypeParts(argType).every(
             (part) =>
               part.flags & ts.TypeFlags.Void ||
-              part.flags & ts.TypeFlags.Undefined
+              part.flags & ts.TypeFlags.Undefined ||
+              part.flags & ts.TypeFlags.Never
           )
         ) {
           context.report({

--- a/rules/no-meaningless-void-operator.js
+++ b/rules/no-meaningless-void-operator.js
@@ -1,0 +1,50 @@
+const { ESLintUtils } = require("@typescript-eslint/experimental-utils");
+const { unionTypeParts } = require("tsutils");
+const ts = require("typescript");
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    schema: [],
+    messages: {
+      meaninglessVoidOperator: `void operator shouldn't be used on {{type}}; it should convey that a return value is being ignored`,
+    },
+  },
+
+  create(context, _options) {
+    const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
+
+    return {
+      [`UnaryExpression[operator="void"]`]: function (node) {
+        const argTsNode = parserServices.esTreeNodeToTSNodeMap.get(
+          node.argument
+        );
+        const argType = checker.getTypeAtLocation(argTsNode);
+        if (
+          unionTypeParts(argType).every(
+            (part) =>
+              part.flags & ts.TypeFlags.Void ||
+              part.flags & ts.TypeFlags.Undefined
+          )
+        ) {
+          context.report({
+            node,
+            messageId: "meaninglessVoidOperator",
+            data: { type: checker.typeToString(argType) },
+            fix(fixer) {
+              const voidToken = parserServices.esTreeNodeToTSNodeMap
+                .get(node)
+                .getChildAt(0);
+              return fixer.removeRange([
+                voidToken.getStart(),
+                voidToken.getEnd(),
+              ]);
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/rules/no-meaningless-void-operator.test.ts
+++ b/rules/no-meaningless-void-operator.test.ts
@@ -1,0 +1,37 @@
+// Use --report-unused-disable-directives to validate errors
+
+void (async () => {
+  // noop
+})();
+
+// eslint-disable-next-line @foxglove/no-meaningless-void-operator
+void (() => {
+  // noop
+})();
+
+function foo(): void {
+  // noop
+}
+function bar(): undefined {
+  return undefined;
+}
+function baz(): number {
+  return 2;
+}
+function maybeBaz(): number | undefined {
+  return 2;
+}
+function maybeNothing(): void | undefined {
+  return;
+}
+
+void foo(); // eslint-disable-line @foxglove/no-meaningless-void-operator
+void bar(); // eslint-disable-line @foxglove/no-meaningless-void-operator
+void baz();
+void void baz(); // eslint-disable-line @foxglove/no-meaningless-void-operator
+void maybeBaz();
+void void maybeBaz(); // eslint-disable-line @foxglove/no-meaningless-void-operator
+void maybeNothing(); // eslint-disable-line @foxglove/no-meaningless-void-operator
+
+// keep isolatedModules happy
+export default {};

--- a/rules/no-meaningless-void-operator.test.ts
+++ b/rules/no-meaningless-void-operator.test.ts
@@ -24,6 +24,9 @@ function maybeBaz(): number | undefined {
 function maybeNothing(): void | undefined {
   return;
 }
+function exit(): never {
+  throw new Error();
+}
 
 void foo(); // eslint-disable-line @foxglove/no-meaningless-void-operator
 void bar(); // eslint-disable-line @foxglove/no-meaningless-void-operator
@@ -32,6 +35,7 @@ void void baz(); // eslint-disable-line @foxglove/no-meaningless-void-operator
 void maybeBaz();
 void void maybeBaz(); // eslint-disable-line @foxglove/no-meaningless-void-operator
 void maybeNothing(); // eslint-disable-line @foxglove/no-meaningless-void-operator
+void exit(); // eslint-disable-line @foxglove/no-meaningless-void-operator
 
 // keep isolatedModules happy
 export default {};


### PR DESCRIPTION
One gap I discovered with @typescript-eslint/no-floating-promises is that there's nothing to remind us to delete these `void` operators if we no longer need them.

Added a new rule to catch this case along with docs:

> Disallow the `void` operator when its argument is already of type `void` or `undefined`.
> 
> The `void` operator is a useful tool to convey the programmer's intent to discard a value. For example, it is recommended as one way of suppressing [`@typescript-eslint/no-floating-promises`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-floating-promises.md) instead of adding `.catch()` to a promise.
> 
> This rule helps an author catch API changes where previously a value was being discarded at a call site, but the callee changed so it no longer returns a value. When combined with [`no-unused-expressions`](https://eslint.org/docs/rules/no-unused-expressions), it also helps _readers_ of the code by ensuring consistency: a statement that looks like `void foo();` is **always** discarding a return value, and a statement that looks like `foo();` is **never** discarding a return value.
> 
> Examples of **incorrect** code for this rule:
> 
> ```ts
> void (() => {})();
> function foo() {}
> void foo();
> ```
> 
> Examples of **correct** code for this rule:
> 
> ```ts
> (() => {})();
> function foo() {}
> foo(); // nothing to discard
> function bar() {
>   return 2;
> }
> void bar(); // discarding a number
> ```