### PR TITLE
Add `no-return-promise-resolve` rule

### DIFF
--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -9,6 +9,7 @@ module.exports = {
     // Avoid #member syntax for performance
     "@foxglove/no-private-identifier": "error",
     "@foxglove/no-meaningless-void-operator": "error",
+    "@foxglove/no-return-promise-resolve": "error",
 
     // `<T>x` style assertions are not compatible with JSX code,
     // so for consistency we prefer `x as T` everywhere.

--- a/configs/typescript.test.ts
+++ b/configs/typescript.test.ts
@@ -19,5 +19,46 @@ void (async () => {
   wut == null ? 0 : 1;
 };
 
+// wrap in an async function to ensure no false positive in nested non-async functions
+async function noReturnPromiseResolve() {
+  await Promise.resolve();
+  function foo() {
+    return Promise.resolve();
+    return Promise.resolve<number>(42);
+    return Promise.reject(42);
+    return Promise.reject<number>(42);
+  }
+  void foo;
+  void (function () {
+    return Promise.resolve();
+  })();
+
+  async function fooAsync() {
+    return Promise.resolve(); // eslint-disable-line @foxglove/no-return-promise-resolve
+    return Promise.resolve<number>(42); // eslint-disable-line @foxglove/no-return-promise-resolve
+    return Promise.reject(42); // eslint-disable-line @foxglove/no-return-promise-resolve
+    return Promise.reject<number>(42); // eslint-disable-line @foxglove/no-return-promise-resolve
+  }
+  void fooAsync;
+  void (async function () {
+    return Promise.resolve(); // eslint-disable-line @foxglove/no-return-promise-resolve
+  })();
+
+  () => Promise.resolve(42);
+  async () => Promise.resolve(42); // eslint-disable-line @foxglove/no-return-promise-resolve
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async () => {
+    Promise.resolve(42); // eslint-disable-line @typescript-eslint/no-floating-promises
+  };
+
+  () => Promise.reject(42);
+  async () => Promise.reject(42); // eslint-disable-line @foxglove/no-return-promise-resolve
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async () => {
+    Promise.reject(42); // eslint-disable-line @typescript-eslint/no-floating-promises
+  };
+}
+void noReturnPromiseResolve;
+
 // keep isolatedModules happy
 export default {};

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
     "no-private-identifier": require("./rules/no-private-identifier"),
     "strict-equality": require("./rules/strict-equality"),
     "no-meaningless-void-operator": require("./rules/no-meaningless-void-operator"),
+    "no-return-promise-resolve": require("./rules/no-return-promise-resolve"),
   },
   configs: {
     base: require("./configs/base"),

--- a/rules/README.md
+++ b/rules/README.md
@@ -34,3 +34,35 @@ function bar() {
 }
 void bar(); // discarding a number
 ```
+
+### [`@foxglove/no-return-promise-resolve`](./no-return-promise-resolve.js) 💭 🔧
+
+Disallow returning `Promise.resolve(...)` or `Promise.reject(...)` inside an async function. This is redundant since an async function will always return a Promise — use `return` or `throw` directly instead.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+async function foo() {
+  return Promise.resolve(0);
+}
+const bar = async function () {
+  return Promise.resolve(9);
+};
+async () => Promise.resolve(3);
+async () => Promise.reject(new Error("boom"));
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+async function foo() {
+  return 0;
+}
+const bar = async function () {
+  return 9;
+};
+async () => 3;
+async () => {
+  throw new Error("boom");
+};
+```

--- a/rules/no-return-promise-resolve.js
+++ b/rules/no-return-promise-resolve.js
@@ -1,0 +1,66 @@
+module.exports = {
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    schema: [],
+    messages: {
+      returnResolve: `Values must be returned directly from async functions`,
+      returnReject: `Errors must be thrown directly from async functions`,
+    },
+  },
+
+  create(context, _options) {
+    return {
+      [`:matches(:function[async=true] ReturnStatement, ArrowFunctionExpression[async=true]) > CallExpression > MemberExpression[object.name="Promise"][property.name=/^(resolve|reject)$/].callee`]:
+        (node) => {
+          // The AST selector ensures that we are somewhere within an async function, but we might
+          // be in a nested function that is not async. Check that the innermost function scope is
+          // actually async.
+          const functionScope = context.getScope().variableScope;
+          if (functionScope.type !== "function" || !functionScope.block.async) {
+            return;
+          }
+          const sourceCode = context.getSourceCode();
+          const returnOrArrowFunction = node.parent.parent;
+          const callExpr = node.parent;
+          const isReturn = returnOrArrowFunction.type === "ReturnStatement";
+          const isArrowFunction = !isReturn;
+          const isReject = node.property.name === "reject";
+          context.report({
+            node: isReject && isReturn ? returnOrArrowFunction : callExpr,
+            messageId: isReject ? "returnReject" : "returnResolve",
+            fix(fixer) {
+              if (callExpr.arguments.length === 0) {
+                return fixer.replaceText(callExpr, "undefined");
+              }
+              if (isReject) {
+                if (isArrowFunction) {
+                  return fixer.replaceText(
+                    returnOrArrowFunction.body,
+                    `{ throw ${sourceCode.getText(callExpr.arguments[0])}; }`
+                  );
+                } else {
+                  return fixer.replaceText(
+                    returnOrArrowFunction,
+                    `throw ${sourceCode.getText(callExpr.arguments[0])};`
+                  );
+                }
+              }
+              const firstArgToken = sourceCode.getFirstToken(
+                callExpr.arguments[0]
+              );
+              const needsParens =
+                isArrowFunction &&
+                firstArgToken.type === "Punctuator" &&
+                firstArgToken.value === "{";
+              const argText = sourceCode.getText(callExpr.arguments[0]);
+              return fixer.replaceText(
+                callExpr,
+                needsParens ? `(${argText})` : argText
+              );
+            },
+          });
+        },
+    };
+  },
+};


### PR DESCRIPTION
Rule docs:

> Disallow returning `Promise.resolve(...)` or `Promise.reject(...)` inside an async function. This is redundant since an async function will always return a Promise — use `return` or `throw` directly instead.
> 
> Examples of **incorrect** code for this rule:
> 
> ```ts
> async function foo() {
>   return Promise.resolve(0);
> }
> const bar = async function () {
>   return Promise.resolve(9);
> };
> async () => Promise.resolve(3);
> async () => Promise.reject(new Error("boom"));
> ```
> 
> Examples of **correct** code for this rule:
> 
> ```ts
> async function foo() {
>   return 0;
> }
> const bar = async function () {
>   return 9;
> };
> async () => 3;
> async () => {
>   throw new Error("boom");
> };
> ```