### PR TITLE
Add es/no-regexp-lookbehind-assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ yarn add -D \
     @typescript-eslint/parser \
     eslint \
     eslint-config-prettier \
+    eslint-plugin-es \
     eslint-plugin-filenames \
     eslint-plugin-import \
     eslint-plugin-jest \

--- a/configs/base.js
+++ b/configs/base.js
@@ -1,11 +1,14 @@
 module.exports = {
   extends: ["eslint:recommended", "plugin:prettier/recommended"],
-  plugins: ["@foxglove", "import", "filenames"],
+  plugins: ["@foxglove", "import", "filenames", "es"],
   parserOptions: {
     ecmaVersion: 2020,
     sourceType: "module",
   },
   rules: {
+    // even new Safari versions do not support regexp lookbehinds
+    "es/no-regexp-lookbehind-assertions": "error",
+
     // import plugin is slow, only enable the critical stuff
     "import/export": "error",
     "import/first": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "peerDependencies": {
         "eslint": "^7",
         "eslint-config-prettier": "^8",
+        "eslint-plugin-es": "^4",
         "eslint-plugin-filenames": "^1",
         "eslint-plugin-import": "^2",
         "eslint-plugin-prettier": "^3",
@@ -888,6 +889,25 @@
       "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-es": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+      "peer": true,
+      "dependencies": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
       }
     },
     "node_modules/eslint-plugin-filenames": {
@@ -3622,6 +3642,16 @@
             }
           }
         },
+        "eslint-plugin-es": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+          "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+          "peer": true,
+          "requires": {
+            "eslint-utils": "^2.0.0",
+            "regexpp": "^3.0.0"
+          }
+        },
         "eslint-plugin-filenames": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/eslint-plugin-filenames/-/eslint-plugin-filenames-1.3.2.tgz",
@@ -5591,6 +5621,16 @@
             "ms": "^2.1.1"
           }
         }
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+      "peer": true,
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
       }
     },
     "eslint-plugin-filenames": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "peerDependencies": {
     "eslint": "^7",
     "eslint-config-prettier": "^8",
+    "eslint-plugin-es": "^4",
     "eslint-plugin-filenames": "^1",
     "eslint-plugin-import": "^2",
     "eslint-plugin-prettier": "^3",


### PR DESCRIPTION
Even Safari 15 TP does not support lookbehinds. This would've prevented https://github.com/foxglove/rosmsg/pull/7