### PR TITLE
Allow nullable objects in boolean expressions

### DIFF
--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -75,7 +75,7 @@ module.exports = {
         allowNumber: false,
         allowNullableNumber: false,
         allowNullableBoolean: false,
-        allowNullableObject: false,
+        allowNullableObject: true,
         allowAny: false,
       },
     ],

--- a/configs/typescript.test.ts
+++ b/configs/typescript.test.ts
@@ -8,17 +8,24 @@ void (async () => {
   await (async function () {})(); // eslint-disable-line @typescript-eslint/no-empty-function
 })();
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(str: string, num: number, wut: any, maybeStr?: string, maybeNum?: number) => {
+(
+  str: string,
+  num: number,
+  wut: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  maybeStr?: string,
+  maybeNum?: number,
+  maybeObj?: Record<string, unknown>
+) => {
   // strict boolean checks are required for everything except strings
   str ? 0 : 1; // allowed
   maybeStr ? 0 : 1; // allowed
   num ? 0 : 1; // eslint-disable-line @typescript-eslint/strict-boolean-expressions
   num == 0 ? 0 : 1; // eslint-disable-line @foxglove/strict-equality
-  num === 0 ? 0 : 1; // correct
+  num === 0 ? 0 : 1; // allowed
   maybeNum ? 0 : 1; // eslint-disable-line @typescript-eslint/strict-boolean-expressions
+  maybeObj ? 0 : 1; // allowed
   wut ? 0 : 1; // eslint-disable-line @typescript-eslint/strict-boolean-expressions
-  wut == null ? 0 : 1;
+  wut == null ? 0 : 1; // allowed
 };
 
 // keep isolatedModules happy

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
     "": {
       "name": "@foxglove/eslint-plugin",
       "version": "0.13.0",
-      "dev": true,
       "license": "MIT",
       "devDependencies": {
         "@foxglove/eslint-plugin": "file:.",
@@ -172,8 +171,8 @@
       }
     },
     "node_modules/@foxglove/eslint-plugin": {
-      "link": true,
-      "resolved": ""
+      "resolved": "",
+      "link": true
     },
     "node_modules/@foxglove/tsconfig": {
       "version": "1.0.0",


### PR DESCRIPTION
Brings shared eslint configuration in line with studio repo.

Alternatively we can ban this syntax in studio repo - I don't have a strong preference either way.