### PR TITLE
Add `no-boolean-parameters` rule

### DIFF
--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -9,6 +9,7 @@ module.exports = {
     // Avoid #member syntax for performance
     "@foxglove/no-private-identifier": "error",
     "@foxglove/no-meaningless-void-operator": "error",
+    "@foxglove/no-boolean-parameters": "error",
 
     // `<T>x` style assertions are not compatible with JSX code,
     // so for consistency we prefer `x as T` everywhere.

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = {
     "strict-equality": require("./rules/strict-equality"),
     "no-meaningless-void-operator": require("./rules/no-meaningless-void-operator"),
     "no-return-promise-resolve": require("./rules/no-return-promise-resolve"),
+    "no-boolean-parameters": require("./rules/no-boolean-parameters"),
   },
   configs: {
     base: require("./configs/base"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,8 +171,8 @@
       }
     },
     "node_modules/@foxglove/eslint-plugin": {
-      "resolved": "",
-      "link": true
+      "link": true,
+      "resolved": ""
     },
     "node_modules/@foxglove/tsconfig": {
       "version": "1.0.0",

--- a/rules/no-boolean-parameters.js
+++ b/rules/no-boolean-parameters.js
@@ -2,6 +2,72 @@ const { ESLintUtils } = require("@typescript-eslint/experimental-utils");
 const { unionTypeParts } = require("tsutils");
 const ts = require("typescript");
 
+function getMessage(param) {
+  let paramName;
+  if (param.type === "AssignmentPattern" && param.left.type === "Identifier") {
+    paramName = param.left.name;
+  } else if (param.type === "Identifier") {
+    paramName = param.name;
+  }
+
+  let funcName;
+  if (param.parent.id) {
+    funcName = param.parent.id.name;
+  } else if (
+    ["Property", "MethodDefinition", "TSAbstractMethodDefinition"].includes(
+      param.parent.parent?.type
+    )
+  ) {
+    funcName = param.parent.parent.key.name;
+  } else if (param.parent.parent?.type === "TSTypeAnnotation") {
+    if (
+      ["TSPropertySignature", "ClassProperty"].includes(
+        param.parent.parent.parent?.type
+      )
+    ) {
+      funcName = param.parent.parent.parent?.key.name;
+    } else {
+      funcName = param.parent.parent.parent?.name;
+    }
+  }
+
+  return `Don't use raw boolean value${
+    paramName ? ` '${paramName}'` : ""
+  } as a parameter${
+    funcName ? ` to '${funcName}'` : ""
+  }; call sites will appear ambiguous (the "boolean trap")`;
+}
+
+function getSuggestions(param, context) {
+  const sourceCode = context.getSourceCode();
+  const suggestions = [];
+
+  let pattern;
+  let typeAnnotation;
+  if (param.type === "AssignmentPattern" && param.left.type === "Identifier") {
+    pattern = `{ ${param.left.name} = ${sourceCode.getText(param.right)} }`;
+    typeAnnotation = `{ ${sourceCode.getText(param.left)}${
+      param.left.typeAnnotation == undefined ? ": boolean" : ""
+    } }`;
+  } else if (param.type === "Identifier") {
+    pattern = `{ ${param.name} }`;
+    typeAnnotation = `{ ${sourceCode.getText(param)}${
+      param.typeAnnotation == undefined ? ": boolean" : ""
+    } }`;
+  }
+
+  if (pattern && typeAnnotation) {
+    suggestions.push({
+      desc: `Replace with ${pattern}`,
+      fix(fixer) {
+        return fixer.replaceText(param, `${pattern}: ${typeAnnotation}`);
+      },
+    });
+  }
+
+  return suggestions;
+}
+
 module.exports = {
   meta: {
     type: "suggestion",
@@ -10,12 +76,11 @@ module.exports = {
   },
 
   create(context, _options) {
-    const sourceCode = context.getSourceCode();
     const { esTreeNodeToTSNodeMap, program } =
       ESLintUtils.getParserServices(context);
     const checker = program.getTypeChecker();
     return {
-      ":function > AssignmentPattern.params, :function > [typeAnnotation].params, TSFunctionType > [typeAnnotation].params":
+      ":function > AssignmentPattern.params, :function > [typeAnnotation].params, TSFunctionType > [typeAnnotation].params, TSEmptyBodyFunctionExpression > [typeAnnotation].params":
         (param) => {
           const tsNode = esTreeNodeToTSNodeMap.get(param);
           const type = checker.getTypeAtLocation(tsNode);
@@ -28,46 +93,13 @@ module.exports = {
                 ts.TypeFlags.Null |
                 ts.TypeFlags.Never)
           );
-          if (!isBoolean) {
-            return;
+          if (isBoolean) {
+            context.report({
+              node: param,
+              message: getMessage(param),
+              suggest: getSuggestions(param, context),
+            });
           }
-          let pattern;
-          let typeAnnotation;
-          if (
-            param.type === "AssignmentPattern" &&
-            param.left.type === "Identifier"
-          ) {
-            pattern = `{ ${param.left.name} = ${sourceCode.getText(
-              param.right
-            )} }`;
-            typeAnnotation = `{ ${sourceCode.getText(param.left)}${
-              param.left.typeAnnotation == undefined ? ": boolean" : ""
-            } }`;
-          } else if (param.type === "Identifier") {
-            pattern = `{ ${param.name} }`;
-            typeAnnotation = `{ ${sourceCode.getText(param)}${
-              param.typeAnnotation == undefined ? ": boolean" : ""
-            } }`;
-          }
-
-          context.report({
-            node: param,
-            message: `Don't use raw boolean values as parameters; call sites will appear ambiguous (the "boolean trap")`,
-            suggest:
-              pattern && typeAnnotation
-                ? [
-                    {
-                      desc: `Replace with ${pattern}`,
-                      fix(fixer) {
-                        return fixer.replaceText(
-                          param,
-                          `${pattern}: ${typeAnnotation}`
-                        );
-                      },
-                    },
-                  ]
-                : undefined,
-          });
         },
     };
   },

--- a/rules/no-boolean-parameters.js
+++ b/rules/no-boolean-parameters.js
@@ -1,0 +1,74 @@
+const { ESLintUtils } = require("@typescript-eslint/experimental-utils");
+const { unionTypeParts } = require("tsutils");
+const ts = require("typescript");
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    fixable: "code",
+    schema: [],
+  },
+
+  create(context, _options) {
+    const sourceCode = context.getSourceCode();
+    const { esTreeNodeToTSNodeMap, program } =
+      ESLintUtils.getParserServices(context);
+    const checker = program.getTypeChecker();
+    return {
+      ":function > AssignmentPattern.params, :function > [typeAnnotation].params, TSFunctionType > [typeAnnotation].params":
+        (param) => {
+          const tsNode = esTreeNodeToTSNodeMap.get(param);
+          const type = checker.getTypeAtLocation(tsNode);
+          const isBoolean = unionTypeParts(type).every(
+            (part) =>
+              part.flags &
+              (ts.TypeFlags.BooleanLike |
+                ts.TypeFlags.Void |
+                ts.TypeFlags.Undefined |
+                ts.TypeFlags.Null |
+                ts.TypeFlags.Never)
+          );
+          if (!isBoolean) {
+            return;
+          }
+          let pattern;
+          let typeAnnotation;
+          if (
+            param.type === "AssignmentPattern" &&
+            param.left.type === "Identifier"
+          ) {
+            pattern = `{ ${param.left.name} = ${sourceCode.getText(
+              param.right
+            )} }`;
+            typeAnnotation = `{ ${sourceCode.getText(param.left)}${
+              param.left.typeAnnotation == undefined ? ": boolean" : ""
+            } }`;
+          } else if (param.type === "Identifier") {
+            pattern = `{ ${param.name} }`;
+            typeAnnotation = `{ ${sourceCode.getText(param)}${
+              param.typeAnnotation == undefined ? ": boolean" : ""
+            } }`;
+          }
+
+          context.report({
+            node: param,
+            message: `Don't use raw boolean values as parameters; call sites will appear ambiguous (the "boolean trap")`,
+            suggest:
+              pattern && typeAnnotation
+                ? [
+                    {
+                      desc: `Replace with ${pattern}`,
+                      fix(fixer) {
+                        return fixer.replaceText(
+                          param,
+                          `${pattern}: ${typeAnnotation}`
+                        );
+                      },
+                    },
+                  ]
+                : undefined,
+          });
+        },
+    };
+  },
+};

--- a/rules/no-boolean-parameters.test.ts
+++ b/rules/no-boolean-parameters.test.ts
@@ -1,0 +1,40 @@
+// Use --report-unused-disable-directives to validate errors
+
+/* eslint-disable @typescript-eslint/no-inferrable-types */
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+void function foo(
+  _a: boolean, // eslint-disable-line @foxglove/no-boolean-parameters
+  _b: boolean = false, // eslint-disable-line @foxglove/no-boolean-parameters
+  _c = true, // eslint-disable-line @foxglove/no-boolean-parameters
+  _d?: false, // eslint-disable-line @foxglove/no-boolean-parameters
+  _e?: boolean | number, // ok
+  _f: boolean | undefined = false // eslint-disable-line @foxglove/no-boolean-parameters
+) {};
+
+// eslint-disable-next-line @foxglove/no-boolean-parameters
+void ((_a: boolean) => {});
+
+type B = boolean;
+void {
+  foo(
+    _a: B, // eslint-disable-line @foxglove/no-boolean-parameters
+    _b?: B | undefined, // eslint-disable-line @foxglove/no-boolean-parameters
+    _c: B | undefined = false // eslint-disable-line @foxglove/no-boolean-parameters
+  ) {},
+};
+
+// Warnings appear only when types are explicitly annotated
+function acceptsFoo(
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  _: (_a: boolean) => void
+) {}
+acceptsFoo((_a) => {}); // ok
+
+void class C {
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  foo(_a: boolean | undefined) {}
+};
+
+// keep isolatedModules happy
+export default {};

--- a/rules/no-boolean-parameters.test.ts
+++ b/rules/no-boolean-parameters.test.ts
@@ -5,11 +5,12 @@
 
 void function foo(
   _a: boolean, // eslint-disable-line @foxglove/no-boolean-parameters
-  _b: boolean = false, // eslint-disable-line @foxglove/no-boolean-parameters
-  _c = true, // eslint-disable-line @foxglove/no-boolean-parameters
-  _d?: false, // eslint-disable-line @foxglove/no-boolean-parameters
-  _e?: boolean | number, // ok
-  _f: boolean | undefined = false // eslint-disable-line @foxglove/no-boolean-parameters
+  _b: boolean | undefined, // eslint-disable-line @foxglove/no-boolean-parameters
+  _c: boolean = false, // eslint-disable-line @foxglove/no-boolean-parameters
+  _d = true, // eslint-disable-line @foxglove/no-boolean-parameters
+  _e?: false, // eslint-disable-line @foxglove/no-boolean-parameters
+  _f?: boolean | number, // ok
+  _g: boolean | undefined = false // eslint-disable-line @foxglove/no-boolean-parameters
 ) {};
 
 // eslint-disable-next-line @foxglove/no-boolean-parameters
@@ -31,10 +32,27 @@ function acceptsFoo(
 ) {}
 acceptsFoo((_a) => {}); // ok
 
-void class C {
+abstract class D {
+  // TSAbstractMethodDefinition
   // eslint-disable-next-line @foxglove/no-boolean-parameters
-  foo(_a: boolean | undefined) {}
+  abstract foo(_a: boolean): void;
+}
+
+void class C extends D {
+  // MethodDefinition
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  foo(_a: boolean) {}
+
+  // ClassProperty
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  bar?: (_b: boolean) => void;
 };
+
+// TSPropertySignature
+({ foo: undefined } as {
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  foo?: (_b: boolean) => void;
+});
 
 // keep isolatedModules happy
 export default {};


### PR DESCRIPTION
Boolean parameters often point to an API anti-pattern called the **boolean trap**. For example, with a function like `repaint(immediate: boolean)`, a reader looking at a call site sees `repaint(true);` and loses key information that `true` means the repaint should be `immediate`. For further reading, see: https://ariya.io/2011/08/hall-of-api-shame-boolean-trap. (Boolean parameters are less problematic in languages like Swift and Objective-C, where function parameters can have _labels_ which are required at the call site, or when editors/IDEs can automatically display the parameter name inline. This is coming to VS Code with future versions of TypeScript; see https://github.com/microsoft/vscode/issues/16221#issuecomment-879538951.)

This PR adds a new rule, `@foxglove/no-boolean-parameters`, which bans boolean parameters to functions. (The rule only works in TypeScript with type information enabled, because it looks at parameter types in function _declarations_, rather than flagging _call sites_ where boolean literals are passed into functions.) The rule also prohibits optional booleans like `immediate?: boolean` or `immediate: boolean = false`, but allows unions of booleans and other types like `value: boolean | number`. This approach was chosen because some common library types like `React.ReactNode` are unions of primitives, and it would be too noisy to prohibit all of these.

The rule supports suggesting an auto-fix by wrapping the parameter in an object with named keys. Future improvements would be to wrap _all_ parameters (not just the single boolean) in a single object, or to migrate the param into an existing object.

https://user-images.githubusercontent.com/14237/131200518-c91fe2f4-67cd-4c91-8fbd-3fc2886fa9fc.mov

In foxglove/studio this rule produces 69 errors.