### PR TITLE
Support eslint-plugin-prettier 4.x.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "devDependencies": {
         "@foxglove/eslint-plugin": "file:.",
-        "@foxglove/tsconfig": "1.0.0",
+        "@foxglove/tsconfig": "1.1.0",
         "@types/jest": "^27",
         "@typescript-eslint/eslint-plugin": "^4.31.0",
         "@typescript-eslint/parser": "^4.31.0",
@@ -28,7 +28,7 @@
         "eslint-plugin-es": "^4",
         "eslint-plugin-filenames": "^1",
         "eslint-plugin-import": "^2",
-        "eslint-plugin-prettier": "^3",
+        "eslint-plugin-prettier": "^3 || ^4",
         "prettier": "^2"
       }
     },
@@ -729,13 +729,13 @@
       }
     },
     "node_modules/@foxglove/eslint-plugin": {
-      "link": true,
-      "resolved": ""
+      "resolved": "",
+      "link": true
     },
     "node_modules/@foxglove/tsconfig": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@foxglove/tsconfig/-/tsconfig-1.0.0.tgz",
-      "integrity": "sha512-JeiZ5AvgPE+tIPJZbzmOXD3ADGpv/y98KpF5Sj6AKi1nhWajcUpiER4Sb6lK5EHxlGF5pRGv7K9riKS1rSMXMw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@foxglove/tsconfig/-/tsconfig-1.1.0.tgz",
+      "integrity": "sha512-qZU4MtXVgPhDBFazSEx7yDEuEg8cPHXFQVhBaUABZkCBdcnEE9sxlgEt0gSikF4fRtY6COGIJPVRflnPJXjJKA==",
       "dev": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -6840,7 +6840,7 @@
       "version": "file:",
       "requires": {
         "@foxglove/eslint-plugin": "file:",
-        "@foxglove/tsconfig": "1.0.0",
+        "@foxglove/tsconfig": "1.1.0",
         "@types/jest": "^27",
         "@typescript-eslint/eslint-plugin": "^4.31.0",
         "@typescript-eslint/parser": "^4.31.0",
@@ -7382,9 +7382,9 @@
           }
         },
         "@foxglove/tsconfig": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@foxglove/tsconfig/-/tsconfig-1.0.0.tgz",
-          "integrity": "sha512-JeiZ5AvgPE+tIPJZbzmOXD3ADGpv/y98KpF5Sj6AKi1nhWajcUpiER4Sb6lK5EHxlGF5pRGv7K9riKS1rSMXMw==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@foxglove/tsconfig/-/tsconfig-1.1.0.tgz",
+          "integrity": "sha512-qZU4MtXVgPhDBFazSEx7yDEuEg8cPHXFQVhBaUABZkCBdcnEE9sxlgEt0gSikF4fRtY6COGIJPVRflnPJXjJKA==",
           "dev": true
         },
         "@istanbuljs/load-nyc-config": {
@@ -11579,9 +11579,9 @@
       }
     },
     "@foxglove/tsconfig": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@foxglove/tsconfig/-/tsconfig-1.0.0.tgz",
-      "integrity": "sha512-JeiZ5AvgPE+tIPJZbzmOXD3ADGpv/y98KpF5Sj6AKi1nhWajcUpiER4Sb6lK5EHxlGF5pRGv7K9riKS1rSMXMw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@foxglove/tsconfig/-/tsconfig-1.1.0.tgz",
+      "integrity": "sha512-qZU4MtXVgPhDBFazSEx7yDEuEg8cPHXFQVhBaUABZkCBdcnEE9sxlgEt0gSikF4fRtY6COGIJPVRflnPJXjJKA==",
       "dev": true
     },
     "@istanbuljs/load-nyc-config": {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "eslint-plugin-es": "^4",
     "eslint-plugin-filenames": "^1",
     "eslint-plugin-import": "^2",
-    "eslint-plugin-prettier": "^3",
+    "eslint-plugin-prettier": "^3 || ^4",
     "prettier": "^2"
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "file:.",
-    "@foxglove/tsconfig": "1.0.0",
+    "@foxglove/tsconfig": "1.1.0",
     "@types/jest": "^27",
     "@typescript-eslint/eslint-plugin": "^4.31.0",
     "@typescript-eslint/parser": "^4.31.0",


### PR DESCRIPTION
Update the `peerDepency` for `eslint-plugin-prettier` to support versions 3 and 4.