### PR TITLE
no-boolean-parameters: improve boolean detection logic to allow never/undefined parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -729,8 +729,8 @@
       }
     },
     "node_modules/@foxglove/eslint-plugin": {
-      "resolved": "",
-      "link": true
+      "link": true,
+      "resolved": ""
     },
     "node_modules/@foxglove/tsconfig": {
       "version": "1.1.0",

--- a/rules/no-boolean-parameters.js
+++ b/rules/no-boolean-parameters.js
@@ -104,15 +104,18 @@ module.exports = {
           }
           const tsNode = esTreeNodeToTSNodeMap.get(param);
           const type = checker.getTypeAtLocation(tsNode);
-          const isBoolean = unionTypeParts(type).every(
-            (part) =>
-              part.flags &
-              (ts.TypeFlags.BooleanLike |
-                ts.TypeFlags.Void |
-                ts.TypeFlags.Undefined |
-                ts.TypeFlags.Null |
-                ts.TypeFlags.Never)
-          );
+          const parts = unionTypeParts(type);
+          const isBoolean =
+            parts.some((part) => part.flags & ts.TypeFlags.BooleanLike) &&
+            parts.every(
+              (part) =>
+                part.flags &
+                (ts.TypeFlags.BooleanLike |
+                  ts.TypeFlags.Void |
+                  ts.TypeFlags.Undefined |
+                  ts.TypeFlags.Null |
+                  ts.TypeFlags.Never)
+            );
           const { paramName, funcName } = getData(param);
           if (isBoolean) {
             context.report({

--- a/rules/no-boolean-parameters.test.ts
+++ b/rules/no-boolean-parameters.test.ts
@@ -17,6 +17,8 @@ const ruleTester = new ESLintUtils.RuleTester({
 ruleTester.run("no-boolean-parameters", rule, {
   valid: [
     "function foo(a: string) {}",
+    "function foo(a: never) {}",
+    "function foo(a: void | undefined) {}",
     `
       function acceptsFoo(_: (a: boolean) => void) {}  // eslint-disable-line no-boolean-parameters
       acceptsFoo((a) => {}); // ok    
@@ -54,6 +56,22 @@ ruleTester.run("no-boolean-parameters", rule, {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
               output: "function foo({ a }: { a: boolean | undefined }) {}",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: "function foo(a: boolean | never) {}",
+      errors: [
+        {
+          messageId: "booleanTrap",
+          data: { paramInfo: ` 'a'`, funcInfo: ` to 'foo'` },
+          suggestions: [
+            {
+              messageId: "wrapParamInObject",
+              data: { pattern: "{ a }" },
+              output: "function foo({ a }: { a: boolean | never }) {}",
             },
           ],
         },


### PR DESCRIPTION
**Public-Facing Changes**
Fixed an issue with `no-boolean-parameters` where an `undefined` or `never` parameter would be incorrectly treated as boolean.