### PR TITLE
set enforceForJSX: true for no-unused-expressions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,9 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
+  "eslint.options": {
+    "reportUnusedDisableDirectives": "error"
+  },
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "prettier.prettierPath": "./node_modules/prettier",

--- a/configs/base.js
+++ b/configs/base.js
@@ -72,7 +72,7 @@ module.exports = {
       },
     ],
 
-    "no-unused-expressions": "error",
+    "no-unused-expressions": ["error", { enforceForJSX: true }],
     "no-param-reassign": "error",
     "no-useless-rename": "error",
     "object-shorthand": "error",

--- a/configs/typescript.example.tsx
+++ b/configs/typescript.example.tsx
@@ -30,5 +30,9 @@ void (async () => {
 
 void undefined; // eslint-disable-line @typescript-eslint/no-meaningless-void-operator
 
+/* eslint-enable @typescript-eslint/no-unused-expressions */
+42; // eslint-disable-line @typescript-eslint/no-unused-expressions
+<></>; // eslint-disable-line @typescript-eslint/no-unused-expressions
+
 // keep isolatedModules happy
 export default {};

--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -31,7 +31,10 @@ module.exports = {
     "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
 
     "no-unused-expressions": "off",
-    "@typescript-eslint/no-unused-expressions": "error",
+    "@typescript-eslint/no-unused-expressions": [
+      "error",
+      { enforceForJSX: true },
+    ],
 
     // The ! assertion may be used sparingly in cases where tsc cannot automatically do bounds
     // checking such as indexed array iteration

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "extends": "@foxglove/tsconfig/base",
   "compilerOptions": {
     "lib": ["es2020", "dom"],
+    "jsx": "preserve",
     "noEmit": true
   }
 }


### PR DESCRIPTION
**Public-Facing Changes**
Enables `enforceForJSX: true` on `no-unused-expressions` rule.


**Description**
This catches errors such as: https://github.com/foxglove/studio/blob/73d748c0ba16cc73f860cd520407f504c530c4a1/packages/studio-base/src/panels/LegacyPlot/index.tsx#L401