### PR TITLE
Update @typescript-eslint/restrict-plus-operands config

### DIFF
--- a/configs/typescript.js
+++ b/configs/typescript.js
@@ -57,12 +57,7 @@ module.exports = {
     "@typescript-eslint/require-await": "off",
 
     // both sides of `+` must be either string or number
-    "@typescript-eslint/restrict-plus-operands": [
-      "error",
-      {
-        checkCompoundAssignments: true,
-      },
-    ],
+    "@typescript-eslint/restrict-plus-operands": "error",
 
     "@typescript-eslint/return-await": ["error", "always"],
 


### PR DESCRIPTION
### Public-Facing Changes
Remove `checkCompoundAssignments` from `@typescript-eslint/restrict-plus-operands`.

This is [now the default](https://github.com/typescript-eslint/typescript-eslint/pull/7027) and our current configuration causes an error.