### PR TITLE
Relax eslint-config-prettier version requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@foxglove/eslint-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@foxglove/eslint-plugin",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^6",
@@ -29,7 +29,7 @@
       },
       "peerDependencies": {
         "eslint": "^7 || ^8",
-        "eslint-config-prettier": "^8",
+        "eslint-config-prettier": "^8 || ^9",
         "eslint-plugin-es": "^4",
         "eslint-plugin-filenames": "^1",
         "eslint-plugin-import": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/eslint-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Foxglove ESLint rules and configuration",
   "license": "MIT",
   "repository": {
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "eslint": "^7 || ^8",
-    "eslint-config-prettier": "^8",
+    "eslint-config-prettier": "^8 || ^9",
     "eslint-plugin-es": "^4",
     "eslint-plugin-filenames": "^1",
     "eslint-plugin-import": "^2",


### PR DESCRIPTION
### Public-Facing Changes

Relaxed peer dependency for eslint-config-prettier to allow v9

### Description

Relates to https://github.com/foxglove/mcap/pull/1014