### PR TITLE
Add no-never-initialized-let rule

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -75,6 +75,7 @@ module.exports = [
 
       // require double equal for null and undefined, triple equal everywhere else
       "@foxglove/strict-equality": "error",
+      "@foxglove/no-never-initialized-let": "error",
       "@foxglove/no-return-promise-resolve": "error",
       "@foxglove/prefer-hash-private": "error",
 

--- a/plugin.js
+++ b/plugin.js
@@ -1,10 +1,11 @@
 /** @type {import("eslint").ESLint.Plugin} */
 module.exports = {
   rules: {
-    "strict-equality": require("./rules/strict-equality"),
-    "no-return-promise-resolve": require("./rules/no-return-promise-resolve"),
     "no-boolean-parameters": require("./rules/no-boolean-parameters"),
+    "no-never-initialized-let": require("./rules/no-never-initialized-let"),
     "no-restricted-imports": require("./rules/no-restricted-imports"),
+    "no-return-promise-resolve": require("./rules/no-return-promise-resolve"),
     "prefer-hash-private": require("./rules/prefer-hash-private"),
+    "strict-equality": require("./rules/strict-equality"),
   },
 };

--- a/rules/README.md
+++ b/rules/README.md
@@ -40,6 +40,38 @@ This rule accepts a single object option with the following default configuratio
 
 - `allowLoneParameter: true` will not report an error if a boolean parameter is the **only** parameter to a function.
 
+### [`@foxglove/no-never-initialized-let`](./no-never-initialized-let.js)
+
+Disallow variable declarations that use `let` but have no intitial value and are never assigned. These variables will always be `undefined` and are likely a programmer error.
+
+The builtin [prefer-const](https://eslint.org/docs/latest/rules/prefer-const) rule doesn't flag these because they lack an initializer. Otherwise, they could be flagged by [init-declarations](https://eslint.org/docs/latest/rules/init-declarations), but this rule is mostly stylistic and has some implications for TypeScript type inference & refinement. (See [eslint/eslint#19581](https://github.com/eslint/eslint/issues/19581) & [microsoft/TypeScript#61496](https://github.com/microsoft/TypeScript/issues/61496) for more discussion.)
+
+Examples of **incorrect** code for this rule:
+
+```ts
+let prevX;
+let prevY;
+if (x !== prevX) {
+  prevX = x;
+}
+if (y !== prevY) {
+  prevX = x; // typo, should have been Y
+}
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+let prevX;
+let prevY;
+if (x !== prevX) {
+  prevX = x;
+}
+if (y !== prevY) {
+  prevY = y;
+}
+```
+
 ### [`@foxglove/no-return-promise-resolve`](./no-return-promise-resolve.js) 🔧
 
 Disallow returning `Promise.resolve(...)` or `Promise.reject(...)` inside an async function. This is redundant since an async function will always return a Promise — use `return` or `throw` directly instead.

--- a/rules/no-never-initialized-let.js
+++ b/rules/no-never-initialized-let.js
@@ -10,7 +10,7 @@ module.exports = {
   create: (context) => {
     const { sourceCode } = context;
     return {
-      [`VariableDeclaration[kind=let] > VariableDeclarator[id.type=Identifier]:not([init])`](
+      [`VariableDeclaration[kind=let]:not([declare=true]) > VariableDeclarator[id.type=Identifier]:not([init])`](
         /** @type {import("estree").VariableDeclarator & { parent: import("eslint").Rule.Node }} */
         node
       ) {

--- a/rules/no-never-initialized-let.js
+++ b/rules/no-never-initialized-let.js
@@ -1,0 +1,31 @@
+/** @type {import("eslint").Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "problem",
+    messages: {
+      letNeverInitialized:
+        "`let` variable is not initialized and never assigned, so it will always be undefined. Use `const` instead.",
+    },
+  },
+  create: (context) => {
+    const { sourceCode } = context;
+    return {
+      [`VariableDeclaration[kind=let] > VariableDeclarator[id.type=Identifier]:not([init])`](
+        /** @type {import("estree").VariableDeclarator & { parent: import("eslint").Rule.Node }} */
+        node
+      ) {
+        for (const variable of sourceCode.getDeclaredVariables(node)) {
+          for (const reference of variable.references) {
+            if (reference.isWrite()) {
+              return;
+            }
+          }
+        }
+        context.report({
+          node,
+          messageId: "letNeverInitialized",
+        });
+      },
+    };
+  },
+};

--- a/rules/no-never-initialized-let.test.ts
+++ b/rules/no-never-initialized-let.test.ts
@@ -21,6 +21,8 @@ let y = undefined;
 let z: number | undefined = undefined;
 let a = x, b = y;
 
+declare let c: string | undefined;
+
 const foo = (two: string): void => {
   let one: string | undefined;
   if (one !== two) {

--- a/rules/no-never-initialized-let.test.ts
+++ b/rules/no-never-initialized-let.test.ts
@@ -1,0 +1,79 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { TSESLint } from "@typescript-eslint/utils";
+
+const rule =
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require("./no-never-initialized-let") as TSESLint.RuleModule<"letNeverInitialized">;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      project: "./tsconfig.test.json",
+    },
+  },
+});
+
+ruleTester.run("no-never-initialized-let", rule, {
+  valid: [
+    /* ts */ `
+const x = undefined;
+let y = undefined;
+let z: number | undefined = undefined;
+let a = x, b = y;
+
+const foo = (two: string): void => {
+  let one: string | undefined;
+  if (one !== two) {
+    one = two;
+  }
+}
+`,
+  ],
+  invalid: [
+    {
+      code: /* ts */ `
+let x;
+let y: number;
+let z: number | undefined;
+let a = x, b;
+      `.trim(),
+      errors: [
+        {
+          messageId: "letNeverInitialized",
+          line: 1,
+          column: 5,
+        },
+        {
+          messageId: "letNeverInitialized",
+          line: 2,
+          column: 5,
+        },
+        {
+          messageId: "letNeverInitialized",
+          line: 3,
+          column: 5,
+        },
+        {
+          messageId: "letNeverInitialized",
+          line: 4,
+          column: 12,
+        },
+      ],
+    },
+    {
+      code: /* ts */ `
+const foo = (two: string): void => {
+  let one: string | undefined;
+  if (one === two) {}
+}
+      `.trim(),
+      errors: [
+        {
+          messageId: "letNeverInitialized",
+          line: 2,
+          column: 7,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
### Changelog
Added `@foxglove/no-never-initialized-let` (enabled by default).

### Docs

Added to readme

### Description

Adds a rule to fill a gap when `init-declarations` is not enabled. Related discussions: https://github.com/eslint/eslint/issues/19581 & https://github.com/microsoft/TypeScript/issues/61496

Copying from readme:

> ### [`@foxglove/no-never-initialized-let`](./no-never-initialized-let.js)
> 
> Disallow variable declarations that use `let` but have no intitial value and are never assigned. These variables will always be `undefined` and are likely a programmer error.
> 
> The builtin [prefer-const](https://eslint.org/docs/latest/rules/prefer-const) rule doesn't flag these because they lack an initializer. Otherwise, they could be flagged by [init-declarations](https://eslint.org/docs/latest/rules/init-declarations), but this rule is mostly stylistic and has some implications for TypeScript type inference & refinement. (See [eslint/eslint#19581](https://github.com/eslint/eslint/issues/19581) & [microsoft/TypeScript#61496](https://github.com/microsoft/TypeScript/issues/61496) for more discussion.)
> 
> Examples of **incorrect** code for this rule:
> 
> ```ts
> let prevX;
> let prevY;
> if (x !== prevX) {
>   prevX = x;
> }
> if (y !== prevY) {
>   prevX = x; // typo, should have been Y
> }
> ```
> 
> Examples of **correct** code for this rule:
> 
> ```ts
> let prevX;
> let prevY;
> if (x !== prevX) {
>   prevX = x;
> }
> if (y !== prevY) {
>   prevY = y;
> }
> ```
> 
> 