### PR TITLE
Release 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@foxglove/eslint-plugin",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@foxglove/eslint-plugin",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@eslint/compat": "^1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/eslint-plugin",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Foxglove ESLint rules and configuration",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
### Changelog
- Bumped eslint peer dependency to `^9.27.0`
- eslint rule `no-unassigned-vars` is now enabled by default.

### Description

🤔 should this be a major version bump? Technically could be a breaking change?