### PR TITLE
Enable NPM trusted publishing with OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      contents: read
       # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
       id-token: write
 
@@ -32,12 +33,6 @@ jobs:
       - run: yarn test
 
       # publish version tags
-      - name: npm publish (dry run)
-        run: npm publish --provenance --access public --dry-run
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - name: npm publish
-        run: npm publish --provenance --access public
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: npx npm@latest publish --provenance --access public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       - run: yarn test
 
       # publish version tags
+      - name: npm publish (dry run)
+        run: yarn npm publish --access public --provenance --dry-run
       - name: npm publish
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: npx npm@latest publish --provenance --access public
+        run: yarn npm publish --access public --provenance

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/eslint-plugin.git"
+    "url": "git+https://github.com/foxglove/eslint-plugin.git"
   },
   "main": "index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Update npm publish workflow to use OIDC trusted publishing with provenance.

## Changes
- Add `id-token: write` and `contents: read` permissions for OIDC authentication
- Update to `yarn npm publish` with `--provenance` flag for supply chain security
- Update actions to v6
- Remove `NODE_AUTH_TOKEN` secret (no longer needed with OIDC)

## Status
✅ Trusted publishing has been configured on npmjs.com for this package.