### PR TITLE
Prefer string union over options object for boolean parameter alternatives

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -10,6 +10,8 @@ Prohibit boolean parameters to functions, including optional parameters and defa
 
 In languages without [argument labels](https://docs.swift.org/swift-book/LanguageGuide/Functions.html), boolean parameters often point to an API anti-pattern called the [**boolean trap**](https://ariya.io/2011/08/hall-of-api-shame-boolean-trap). For example, with a function like `repaint(immediate: boolean)`, a reader looking at a call site sees `repaint(true);` and loses key context that `true` means the repaint should be `immediate`.
 
+The preferred alternative is to use a **string union** so that call sites are self-documenting (e.g., `draw("immediate")` instead of `draw(true)`). Wrapping the boolean in an options object is also acceptable.
+
 This rule does currently allow unions of booleans and other types like `value: boolean | number`. This approach was chosen because some common library types like `React.ReactNode` are unions of primitives, and it would be too noisy to prohibit all of these.
 
 Examples of **incorrect** code for this rule:
@@ -23,6 +25,12 @@ const draw = (immediate = false) => {};
 Examples of **correct** code for this rule:
 
 ```ts
+// Preferred: use a string union
+function draw(immediate: "immediate" | "not-immediate") {}
+const draw = (immediate?: "immediate" | "not-immediate") => {};
+const draw = (immediate: "immediate" | "not-immediate" = "not-immediate") => {};
+
+// Alternative: wrap in an options object
 function draw({ immediate }: { immediate: boolean }) {}
 const draw = ({ immediate }: { immediate?: boolean }) => {};
 const draw = ({ immediate = false }: { immediate: boolean }) => {};

--- a/rules/README.md
+++ b/rules/README.md
@@ -10,7 +10,7 @@ Prohibit boolean parameters to functions, including optional parameters and defa
 
 In languages without [argument labels](https://docs.swift.org/swift-book/LanguageGuide/Functions.html), boolean parameters often point to an API anti-pattern called the [**boolean trap**](https://ariya.io/2011/08/hall-of-api-shame-boolean-trap). For example, with a function like `repaint(immediate: boolean)`, a reader looking at a call site sees `repaint(true);` and loses key context that `true` means the repaint should be `immediate`.
 
-The preferred alternative is to use a **string union** so that call sites are self-documenting (e.g., `draw("immediate")` instead of `draw(true)`). Wrapping the boolean in an options object is also acceptable.
+The preferred alternative is to use a **string union** so that call sites are self-documenting (e.g., `draw("immediate")` instead of `draw(true)`). Wrapping the boolean in an options object is also acceptable, and may be a better choice when you anticipate the function accepting additional options in the future — an options object is easier to extend without changing existing call sites.
 
 This rule does currently allow unions of booleans and other types like `value: boolean | number`. This approach was chosen because some common library types like `React.ReactNode` are unions of primitives, and it would be too noisy to prohibit all of these.
 

--- a/rules/README.md
+++ b/rules/README.md
@@ -26,9 +26,9 @@ Examples of **correct** code for this rule:
 
 ```ts
 // Preferred: use a string union
-function draw(immediate: "immediate" | "not-immediate") {}
-const draw = (immediate?: "immediate" | "not-immediate") => {};
-const draw = (immediate: "immediate" | "not-immediate" = "not-immediate") => {};
+function draw(immediate: "immediate" | "lazy") {}
+const draw = (immediate?: "immediate" | "lazy") => {};
+const draw = (immediate: "immediate" | "lazy" = "lazy") => {};
 
 // Alternative: wrap in an options object
 function draw({ immediate }: { immediate: boolean }) {}

--- a/rules/no-boolean-parameters.js
+++ b/rules/no-boolean-parameters.js
@@ -2,7 +2,7 @@ const { ESLintUtils } = require("@typescript-eslint/utils");
 const { unionTypeParts } = require("tsutils");
 const ts = require("typescript");
 
-/** @typedef {"booleanTrap" | "wrapParamInObject"} MessageIds */
+/** @typedef {"booleanTrap" | "useStringUnion" | "wrapParamInObject"} MessageIds */
 /** @typedef {[{ allowLoneParameter: boolean }]} Options */
 
 /**
@@ -52,6 +52,84 @@ function getData(param) {
   }
 
   return { paramName, funcName };
+}
+
+/**
+ * @param {import("@typescript-eslint/typescript-estree").TSESTree.Node} param
+ * @param {import("@typescript-eslint/utils").TSESLint.RuleContext<MessageIds, Options>} context
+ */
+function getStringUnionSuggestions(param, context) {
+  const { sourceCode } = context;
+  /** @type {import("@typescript-eslint/utils").TSESLint.SuggestionReportDescriptor<MessageIds>[]} */
+  const suggestions = [];
+
+  /** @type {string | undefined} */
+  let paramName;
+  /** @type {import("@typescript-eslint/typescript-estree").TSESTree.Identifier | undefined} */
+  let paramNode;
+  if (param.type === "AssignmentPattern" && param.left.type === "Identifier") {
+    paramName = param.left.name;
+    paramNode = param.left;
+  } else if (param.type === "Identifier") {
+    paramName = param.name;
+    paramNode = param;
+  }
+
+  if (!paramName || !paramNode) {
+    return suggestions;
+  }
+
+  const positiveValue = `"${paramName}"`;
+  const negativeValue = `"not-${paramName}"`;
+
+  // Collect non-boolean union parts from the AST type annotation
+  /** @type {string[]} */
+  const nonBooleanParts = [];
+  if (paramNode.typeAnnotation) {
+    const typeNode = paramNode.typeAnnotation.typeAnnotation;
+    if (typeNode.type === "TSUnionType") {
+      for (const member of typeNode.types) {
+        if (
+          member.type === "TSUndefinedKeyword" ||
+          member.type === "TSNullKeyword" ||
+          member.type === "TSVoidKeyword"
+        ) {
+          nonBooleanParts.push(sourceCode.getText(member));
+        }
+      }
+    }
+  }
+
+  // Build type string
+  let typeStr = `${positiveValue} | ${negativeValue}`;
+  if (nonBooleanParts.length > 0) {
+    typeStr += ` | ${nonBooleanParts.join(" | ")}`;
+  }
+
+  // Build default value mapping: true → positive, false → negative
+  let defaultStr = "";
+  if (param.type === "AssignmentPattern") {
+    const defaultText = sourceCode.getText(param.right);
+    if (defaultText === "true") {
+      defaultStr = ` = ${positiveValue}`;
+    } else if (defaultText === "false") {
+      defaultStr = ` = ${negativeValue}`;
+    }
+  }
+
+  const optional = paramNode.optional ? "?" : "";
+  const replacement = `${paramName}${optional}: ${typeStr}${defaultStr}`;
+  const union = `${positiveValue} | ${negativeValue}`;
+
+  suggestions.push({
+    messageId: "useStringUnion",
+    data: { union },
+    fix(fixer) {
+      return fixer.replaceText(param, replacement);
+    },
+  });
+
+  return suggestions;
 }
 
 /**
@@ -112,6 +190,7 @@ module.exports = {
     ],
     messages: {
       booleanTrap: `Don't use raw boolean value{{paramInfo}} as a parameter{{funcInfo}}; call sites will appear ambiguous (the "boolean trap")`,
+      useStringUnion: `Replace with string union {{union}}`,
       wrapParamInObject: `Replace with {{pattern}}`,
     },
   },
@@ -159,7 +238,10 @@ module.exports = {
                 paramInfo: paramName ? ` '${paramName}'` : "",
                 funcInfo: funcName ? ` to '${funcName}'` : "",
               },
-              suggest: getSuggestions(param, context),
+              suggest: [
+                ...getStringUnionSuggestions(param, context),
+                ...getSuggestions(param, context),
+              ],
             });
           }
         },

--- a/rules/no-boolean-parameters.js
+++ b/rules/no-boolean-parameters.js
@@ -238,6 +238,9 @@ module.exports = {
                 paramInfo: paramName ? ` '${paramName}'` : "",
                 funcInfo: funcName ? ` to '${funcName}'` : "",
               },
+              // String union is listed first as the generally preferred approach.
+              // The options object alternative may be better when the function is
+              // likely to accept additional options in the future.
               suggest: [
                 ...getStringUnionSuggestions(param, context),
                 ...getSuggestions(param, context),

--- a/rules/no-boolean-parameters.js
+++ b/rules/no-boolean-parameters.js
@@ -79,8 +79,8 @@ function getStringUnionSuggestions(param, context) {
     return suggestions;
   }
 
-  const positiveValue = `"${paramName}"`;
-  const negativeValue = `"not-${paramName}"`;
+  const positiveValue = `"a"`;
+  const negativeValue = `"b"`;
 
   // Collect non-boolean union parts from the AST type annotation
   /** @type {string[]} */

--- a/rules/no-boolean-parameters.test.ts
+++ b/rules/no-boolean-parameters.test.ts
@@ -3,7 +3,7 @@ import { TSESLint } from "@typescript-eslint/utils";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const rule = require("./no-boolean-parameters") as TSESLint.RuleModule<
-  "booleanTrap" | "wrapParamInObject",
+  "booleanTrap" | "useStringUnion" | "wrapParamInObject",
   [{ allowLoneParameter: boolean }]
 >;
 
@@ -38,6 +38,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'foo'` },
           suggestions: [
             {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `function foo(a: "a" | "not-a") {}`,
+            },
+            {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
               output: "function foo({ a }: { a: boolean }) {}",
@@ -54,6 +59,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'foo'` },
           suggestions: [
             {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `function foo(a: "a" | "not-a" | undefined) {}`,
+            },
+            {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
               output: "function foo({ a }: { a: boolean | undefined }) {}",
@@ -69,6 +79,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           messageId: "booleanTrap",
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'foo'` },
           suggestions: [
+            {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `function foo(a: "a" | "not-a") {}`,
+            },
             {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
@@ -87,6 +102,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'foo'` },
           suggestions: [
             {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `function foo(a: "a" | "not-a" = "not-a") {}`,
+            },
+            {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a = false }" },
               output: "function foo({ a = false }: { a: boolean }) {}",
@@ -102,6 +122,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           messageId: "booleanTrap",
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'foo'` },
           suggestions: [
+            {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `function foo(a: "a" | "not-a" = "a") {}`,
+            },
             {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a = true }" },
@@ -119,6 +144,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'foo'` },
           suggestions: [
             {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `function foo(a?: "a" | "not-a") {}`,
+            },
+            {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
               output: "function foo({ a }: { a?: false }) {}",
@@ -134,6 +164,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           messageId: "booleanTrap",
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'foo'` },
           suggestions: [
+            {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `function foo(a: "a" | "not-a" | undefined = "not-a") {}`,
+            },
             {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a = false }" },
@@ -152,6 +187,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'foo'` },
           suggestions: [
             {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `const foo = function (a: "a" | "not-a") {}`,
+            },
+            {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
               output: "const foo = function ({ a }: { a: boolean }) {}",
@@ -167,6 +207,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           messageId: "booleanTrap",
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'foo'` },
           suggestions: [
+            {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `type B = boolean; function foo(a: "a" | "not-a") {}`,
+            },
             {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
@@ -184,6 +229,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           data: { paramInfo: ` 'a'`, funcInfo: `` },
           suggestions: [
             {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `((a: "a" | "not-a") => {})`,
+            },
+            {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
               output: "(({ a }: { a: boolean }) => {})",
@@ -199,6 +249,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           messageId: "booleanTrap",
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'x'` },
           suggestions: [
+            {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `({ x(a: "a" | "not-a") {} })`,
+            },
             {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
@@ -216,6 +271,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'x'` },
           suggestions: [
             {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `({ x: (a: "a" | "not-a") => {} })`,
+            },
+            {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
               output: "({ x: ({ a }: { a: boolean }) => {} })",
@@ -231,6 +291,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           messageId: "booleanTrap",
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'x'` },
           suggestions: [
+            {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `function x(a: "a" | "not-a") {}`,
+            },
             {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
@@ -248,6 +313,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'x'` },
           suggestions: [
             {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `async function x(a: "a" | "not-a") {}`,
+            },
+            {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
               output: "async function x({ a }: { a: boolean }) {}",
@@ -263,6 +333,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           messageId: "booleanTrap",
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'x'` },
           suggestions: [
+            {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `class C { x(a: "a" | "not-a") {} }`,
+            },
             {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
@@ -280,6 +355,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'x'` },
           suggestions: [
             {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `class C { x?: (a: "a" | "not-a") => void; }`,
+            },
+            {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
               output: "class C { x?: ({ a }: { a: boolean }) => void; }",
@@ -295,6 +375,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           messageId: "booleanTrap",
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'x'` },
           suggestions: [
+            {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `abstract class C { abstract x(a: "a" | "not-a"): void; }`,
+            },
             {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },
@@ -312,6 +397,11 @@ ruleTester.run("no-boolean-parameters", rule, {
           messageId: "booleanTrap",
           data: { paramInfo: ` 'a'`, funcInfo: ` to 'x'` },
           suggestions: [
+            {
+              messageId: "useStringUnion",
+              data: { union: `"a" | "not-a"` },
+              output: `type T = { x?: (a: "a" | "not-a") => void; }`,
+            },
             {
               messageId: "wrapParamInObject",
               data: { pattern: "{ a }" },

--- a/rules/no-boolean-parameters.test.ts
+++ b/rules/no-boolean-parameters.test.ts
@@ -39,8 +39,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `function foo(a: "a" | "not-a") {}`,
+              data: { union: `"a" | "b"` },
+              output: `function foo(a: "a" | "b") {}`,
             },
             {
               messageId: "wrapParamInObject",
@@ -60,8 +60,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `function foo(a: "a" | "not-a" | undefined) {}`,
+              data: { union: `"a" | "b"` },
+              output: `function foo(a: "a" | "b" | undefined) {}`,
             },
             {
               messageId: "wrapParamInObject",
@@ -81,8 +81,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `function foo(a: "a" | "not-a") {}`,
+              data: { union: `"a" | "b"` },
+              output: `function foo(a: "a" | "b") {}`,
             },
             {
               messageId: "wrapParamInObject",
@@ -103,8 +103,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `function foo(a: "a" | "not-a" = "not-a") {}`,
+              data: { union: `"a" | "b"` },
+              output: `function foo(a: "a" | "b" = "b") {}`,
             },
             {
               messageId: "wrapParamInObject",
@@ -124,8 +124,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `function foo(a: "a" | "not-a" = "a") {}`,
+              data: { union: `"a" | "b"` },
+              output: `function foo(a: "a" | "b" = "a") {}`,
             },
             {
               messageId: "wrapParamInObject",
@@ -145,8 +145,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `function foo(a?: "a" | "not-a") {}`,
+              data: { union: `"a" | "b"` },
+              output: `function foo(a?: "a" | "b") {}`,
             },
             {
               messageId: "wrapParamInObject",
@@ -166,8 +166,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `function foo(a: "a" | "not-a" | undefined = "not-a") {}`,
+              data: { union: `"a" | "b"` },
+              output: `function foo(a: "a" | "b" | undefined = "b") {}`,
             },
             {
               messageId: "wrapParamInObject",
@@ -188,8 +188,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `const foo = function (a: "a" | "not-a") {}`,
+              data: { union: `"a" | "b"` },
+              output: `const foo = function (a: "a" | "b") {}`,
             },
             {
               messageId: "wrapParamInObject",
@@ -209,8 +209,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `type B = boolean; function foo(a: "a" | "not-a") {}`,
+              data: { union: `"a" | "b"` },
+              output: `type B = boolean; function foo(a: "a" | "b") {}`,
             },
             {
               messageId: "wrapParamInObject",
@@ -230,8 +230,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `((a: "a" | "not-a") => {})`,
+              data: { union: `"a" | "b"` },
+              output: `((a: "a" | "b") => {})`,
             },
             {
               messageId: "wrapParamInObject",
@@ -251,8 +251,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `({ x(a: "a" | "not-a") {} })`,
+              data: { union: `"a" | "b"` },
+              output: `({ x(a: "a" | "b") {} })`,
             },
             {
               messageId: "wrapParamInObject",
@@ -272,8 +272,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `({ x: (a: "a" | "not-a") => {} })`,
+              data: { union: `"a" | "b"` },
+              output: `({ x: (a: "a" | "b") => {} })`,
             },
             {
               messageId: "wrapParamInObject",
@@ -293,8 +293,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `function x(a: "a" | "not-a") {}`,
+              data: { union: `"a" | "b"` },
+              output: `function x(a: "a" | "b") {}`,
             },
             {
               messageId: "wrapParamInObject",
@@ -314,8 +314,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `async function x(a: "a" | "not-a") {}`,
+              data: { union: `"a" | "b"` },
+              output: `async function x(a: "a" | "b") {}`,
             },
             {
               messageId: "wrapParamInObject",
@@ -335,8 +335,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `class C { x(a: "a" | "not-a") {} }`,
+              data: { union: `"a" | "b"` },
+              output: `class C { x(a: "a" | "b") {} }`,
             },
             {
               messageId: "wrapParamInObject",
@@ -356,8 +356,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `class C { x?: (a: "a" | "not-a") => void; }`,
+              data: { union: `"a" | "b"` },
+              output: `class C { x?: (a: "a" | "b") => void; }`,
             },
             {
               messageId: "wrapParamInObject",
@@ -377,8 +377,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `abstract class C { abstract x(a: "a" | "not-a"): void; }`,
+              data: { union: `"a" | "b"` },
+              output: `abstract class C { abstract x(a: "a" | "b"): void; }`,
             },
             {
               messageId: "wrapParamInObject",
@@ -399,8 +399,8 @@ ruleTester.run("no-boolean-parameters", rule, {
           suggestions: [
             {
               messageId: "useStringUnion",
-              data: { union: `"a" | "not-a"` },
-              output: `type T = { x?: (a: "a" | "not-a") => void; }`,
+              data: { union: `"a" | "b"` },
+              output: `type T = { x?: (a: "a" | "b") => void; }`,
             },
             {
               messageId: "wrapParamInObject",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the `@foxglove/no-boolean-parameters` rule to offer a **string union** as the preferred suggestion for replacing boolean parameters, in addition to the existing wrap-in-options-object suggestion.

## Motivation

When the rule detects a boolean parameter, it previously only suggested wrapping it in an options object:

```ts
// Before (only suggestion)
function draw({ immediate }: { immediate: boolean }) {}
```

String unions are generally preferred unless the function already uses an options object:

```ts
// draw("immediate") vs draw(true)
function draw(immediate: "immediate" | "lazy") {}
```

## Changes

### `rules/no-boolean-parameters.js`
- Added a new `useStringUnion` message ID and suggestion
- The string union suggestion appears **first** (preferred), followed by the existing `wrapParamInObject` suggestion
- Uses generic `"a" | "b"` placeholders since the developer will customize the values to be domain-appropriate
- Handles all edge cases:
  - Default values: `= true` → `= "a"`, `= false` → `= "b"`
  - Optional parameters (`?`) preserved
  - Non-boolean union members (`undefined`, `null`, `void`) preserved
  - Type aliases resolved correctly

### `rules/no-boolean-parameters.test.ts`
- All 18 invalid test cases updated with `useStringUnion` as the first suggestion entry
- Existing `wrapParamInObject` expectations preserved as the second entry

### `rules/README.md`
- Updated documentation to recommend string unions as the preferred pattern
- Options object wrapping shown as an alternative

## Examples

| Input | String union suggestion (preferred) | Object suggestion (alternative) |
|---|---|---|
| `foo(a: boolean)` | `foo(a: "a" \| "b")` | `foo({ a }: { a: boolean })` |
| `foo(a: boolean = false)` | `foo(a: "a" \| "b" = "b")` | `foo({ a = false }: { a: boolean })` |
| `foo(a?: boolean)` | `foo(a?: "a" \| "b")` | `foo({ a }: { a?: boolean })` |
| `foo(a: boolean \| undefined)` | `foo(a: "a" \| "b" \| undefined)` | `foo({ a }: { a: boolean \| undefined })` |

## Testing

- ✅ `yarn build`
- ✅ `yarn test` — 44/44 tests pass
- ✅ `yarn fmt:check`
- ✅ `yarn lint:check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-518777b6-c1af-40e4-b549-321142bf1c5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-518777b6-c1af-40e4-b549-321142bf1c5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

