### PR TITLE
Fix missing plugin.js in published package (v2.1.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "types": "dist/index.d.ts",
   "files": [
     "**/*.js",
+    "plugin.js",
     "dist"
   ],
   "packageManager": "yarn@4.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/eslint-plugin",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Foxglove ESLint rules and configuration",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem

After the Yarn migration (#69) and the v2.1.1 release (#83), downstream consumers get:

```
Error: Cannot find module './plugin'
Require stack:
- node_modules/@foxglove/eslint-plugin/index.js
```

### Root cause

`index.js` requires `./plugin`, but `plugin.js` is not included in the published npm package.

The `files` array in `package.json` uses `"**/*.js"` to include JavaScript files. While npm treats this glob as matching all `.js` files including those at the root, Yarn 4's `pack` command does not match root-level files with `**/*.js`. As a result:

- `index.js` is included because it's the `main` entry point (always auto-included by npm/yarn)
- `configs/*.js` and `rules/*.js` are included because they're in subdirectories
- `plugin.js` at the root is **not** matched and silently excluded

### Fix

Add `plugin.js` explicitly to the `files` array so it is always included in the published package regardless of glob behavior differences between package managers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ca496a4-ff18-4ef8-baf9-3a9b960da71d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ca496a4-ff18-4ef8-baf9-3a9b960da71d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

